### PR TITLE
Prompt user that a TK window needs attention

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Release 0.1-2 (//):
   * Fix vignette title.
+  * Add console notification when using tcltk
 
 Release 0.1-1 (4/25/2016):
   * Add package vignette.

--- a/R/getPass.r
+++ b/R/getPass.r
@@ -133,7 +133,7 @@ readline_masked_tcltk <- function(msg)
   textbox <- tcltk::tkentry(f1, textvariable = pwdvar, show = "*")
   tcltk::tkpack(textbox, side = "left")
   tcltk::tkbind(textbox, "<Return>", submit)
-  if(.Platform$OS == "windows")
+  if(.Platform$OS.type == "windows")
     tcltk::tkbind(textbox, "<Escape>", cleanup)
   else
     tcltk::tkbind(textbox, "<Control-c>", cleanup)
@@ -147,6 +147,7 @@ readline_masked_tcltk <- function(msg)
   # Add focus
   tcltk::tkwm.minsize(tt, "300", "40")
   tcltk::tkwm.deiconify(tt)
+  message("Please enter password in TK window")
   tcltk::tkfocus(textbox)
   
   # Wait for destroy signal


### PR DESCRIPTION
On windows (at least windows 7 computers I have worked with), the TK window
will not raise to the front with `tkfocus`.  This can lead to hard-to-diagnose
issues where a password is being prompted for but the user does not know this.
Other platforms may have similar issues, as I believe that window focussing
is not compulsary and the window will not be treated like a modal dialog (vs
the rstudioapi approach which is really slick).

This commit just adds a small message to the console indicating that the TK
window will need some input.

(there is also a fix of a partial `$` match of OS -> OS.type)
